### PR TITLE
Fix 'use strict' typo

### DIFF
--- a/src/utils/ignoreCookie.js
+++ b/src/utils/ignoreCookie.js
@@ -1,4 +1,4 @@
-'use static'
+'use strict'
 
 const COOKIE_NAME = 'ackee_ignore'
 


### PR DESCRIPTION
## Summary
- fix strict mode directive typo in ignoreCookie

## Testing
- `npm test` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_b_68782e672814832a979eb611cd1c75f2